### PR TITLE
Add unit tests for the order service

### DIFF
--- a/src/test/java/red/softn/npedidos/service/OrderServiceTest.java
+++ b/src/test/java/red/softn/npedidos/service/OrderServiceTest.java
@@ -1,0 +1,24 @@
+package red.softn.npedidos.service;
+
+import lombok.Getter;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import red.softn.npedidos.CrudServiceTest;
+import red.softn.npedidos.entity.Order;
+import red.softn.npedidos.repository.OrderRepository;
+import red.softn.npedidos.request.OrderRequest;
+import red.softn.npedidos.response.OrderResponse;
+
+@ExtendWith(MockitoExtension.class)
+@Getter
+class OrderServiceTest extends CrudServiceTest<OrderRequest, OrderResponse, Order, Integer, OrderServiceTestUtil> {
+    
+    @InjectMocks
+    private OrderService service;
+    
+    @Mock
+    private OrderRepository repository;
+    
+}

--- a/src/test/java/red/softn/npedidos/service/OrderServiceTestUtil.java
+++ b/src/test/java/red/softn/npedidos/service/OrderServiceTestUtil.java
@@ -1,0 +1,40 @@
+package red.softn.npedidos.service;
+
+import net.datafaker.Faker;
+import red.softn.npedidos.CrudServiceTestUtil;
+import red.softn.npedidos.entity.FoodDish;
+import red.softn.npedidos.entity.Order;
+import red.softn.npedidos.request.FoodDishRequest;
+import red.softn.npedidos.request.OrderRequest;
+import red.softn.npedidos.response.FoodDishResponse;
+import red.softn.npedidos.response.OrderResponse;
+
+import java.time.LocalDateTime;
+
+public class OrderServiceTestUtil extends CrudServiceTestUtil<OrderRequest, OrderResponse, Order, Integer> {
+    
+    public OrderServiceTestUtil(Faker faker) {
+        super(faker);
+    }
+    
+    @Override
+    public Init<OrderRequest, OrderResponse, Order, Integer> init() {
+    
+        var request = new OrderRequest();
+        var response = new OrderResponse();
+        var entity = new Order();
+        var entitySaveResult = new Order();
+    
+        entity.setId(fakeRandomInteger());
+        entity.setDateOrder(LocalDateTime.of(2022, 10, 10, 10, 10));
+        entitySaveResult.setId(entity.getId());
+        entitySaveResult.setDateOrder(entity.getDateOrder());
+        response.setId(entity.getId());
+        response.setDateOrder(entity.getDateOrder());
+        request.setId(entity.getId());
+        request.setDateOrder(entity.getDateOrder());
+    
+        return Init.of(request, response, entity, entitySaveResult, entity.getId());
+    }
+    
+}

--- a/src/test/java/red/softn/npedidos/service/OrderServiceTestUtil.java
+++ b/src/test/java/red/softn/npedidos/service/OrderServiceTestUtil.java
@@ -26,7 +26,7 @@ public class OrderServiceTestUtil extends CrudServiceTestUtil<OrderRequest, Orde
         var entitySaveResult = new Order();
     
         entity.setId(fakeRandomInteger());
-        entity.setDateOrder(LocalDateTime.of(2022, 10, 10, 10, 10));
+        entity.setDateOrder(fakeDateFutureDays().atStartOfDay());
         entitySaveResult.setId(entity.getId());
         entitySaveResult.setDateOrder(entity.getDateOrder());
         response.setId(entity.getId());


### PR DESCRIPTION
Se agregan pruebas unitarias para la clase `OrderService` siguiendo la estructura sugerida 

Issues #8 